### PR TITLE
[persist-database-locally] Keep the database data locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log
 staticfiles/
 dump.rdb
 /env
+/postgres
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     image: postgres:10.6
     environment:
       - POSTGRES_USER=metashare
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
 
   # Runs the queue process:
   redis:


### PR DESCRIPTION
This should make a gitignored postgres directory, and save your db data in it, between calls to down, build, etc.

You will want to run:

```
make down
make build
make up
```

to get these changes in locally, I think.

![red wolf](https://www.zooborns.com/.a/6a010535647bf3970b0240a49477af200d-800wi)