### PR TITLE
[dry-actions] 🧶 Abstract generic fetchObject(s) actions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.1",
     "eslint-plugin-simple-import-sort": "^4.0.0",
-    "fetch-mock": "^7.3.3",
+    "fetch-mock": "^7.3.6",
     "file-loader": "^4.0.0",
     "html-webpack-plugin": "^3.2.0",
     "i18next-scanner-webpack": "^0.4.0",

--- a/src/js/components/products/detail.tsx
+++ b/src/js/components/products/detail.tsx
@@ -11,24 +11,28 @@ import { Link, Redirect, RouteComponentProps } from 'react-router-dom';
 
 import ProductNotFound from '@/components/products/product404';
 import { AppState } from '@/store';
-import { fetchProduct } from '@/store/products/actions';
+import { fetchObject, ObjectsActionType } from '@/store/actions';
 import { Product } from '@/store/products/reducer';
 import { selectProduct, selectProductSlug } from '@/store/products/selectors';
+import { OBJECT_TYPES } from '@/utils/constants';
 import routes from '@/utils/routes';
 
 type Props = {
   product?: Product | null;
   productSlug?: string;
-  doFetchProduct({ slug }: { slug: string }): Promise<any>;
+  doFetchObject: ObjectsActionType;
 } & RouteComponentProps;
 
-const ProductDetail = ({ product, productSlug, doFetchProduct }: Props) => {
+const ProductDetail = ({ product, productSlug, doFetchObject }: Props) => {
   useEffect(() => {
     if (productSlug && product === undefined) {
       // Fetch product from API
-      doFetchProduct({ slug: productSlug });
+      doFetchObject({
+        objectType: OBJECT_TYPES.PRODUCT,
+        filters: { slug: productSlug },
+      });
     }
-  }, [product, productSlug, doFetchProduct]);
+  }, [product, productSlug, doFetchObject]);
 
   if (!product) {
     if (!productSlug || product === null) {
@@ -132,7 +136,7 @@ const select = (appState: AppState, props: Props) => ({
   product: selectProduct(appState, props),
 });
 const actions = {
-  doFetchProduct: fetchProduct,
+  doFetchObject: fetchObject,
 };
 const WrappedProductDetail = connect(
   select,

--- a/src/js/components/products/list.tsx
+++ b/src/js/components/products/list.tsx
@@ -12,20 +12,22 @@ import { EmptyIllustration } from '@/components/404';
 import ProductListItem from '@/components/products/listItem';
 import { LabelWithSpinner } from '@/components/utils';
 import { AppState } from '@/store';
-import { fetchMoreProducts, syncRepos } from '@/store/products/actions';
+import { fetchObjects, ObjectsActionType } from '@/store/actions';
+import { syncRepos } from '@/store/products/actions';
 import { Product } from '@/store/products/reducer';
 import { selectNextUrl, selectProducts } from '@/store/products/selectors';
+import { OBJECT_TYPES } from '@/utils/constants';
 
 interface Props {
   y: number;
   products: Product[];
   next: string | null;
-  doFetchMoreProducts({ url }: { url: string }): Promise<any>;
+  doFetchObjects: ObjectsActionType;
   doSyncRepos(): Promise<any>;
 }
 
 const ProductList = withScroll(
-  ({ y, products, next, doFetchMoreProducts, doSyncRepos }: Props) => {
+  ({ y, products, next, doFetchObjects, doSyncRepos }: Props) => {
     const [fetchingProducts, setFetchingProducts] = useState(false);
     const [syncingRepos, setSyncingRepos] = useState(false);
 
@@ -45,7 +47,10 @@ const ProductList = withScroll(
         /* istanbul ignore else */
         if (next && !fetchingProducts) {
           setFetchingProducts(true);
-          doFetchMoreProducts({ url: next }).finally(() => {
+          doFetchObjects({
+            objectType: OBJECT_TYPES.PRODUCT,
+            url: next,
+          }).finally(() => {
             setFetchingProducts(false);
           });
         }
@@ -67,7 +72,7 @@ const ProductList = withScroll(
       if (scrolledToBottom) {
         maybeFetchMoreProducts();
       }
-    }, [y, next, fetchingProducts, doFetchMoreProducts]);
+    }, [y, next, fetchingProducts, doFetchObjects]);
 
     let contents;
     switch (products.length) {
@@ -178,7 +183,7 @@ const select = (appState: AppState) => ({
 });
 
 const actions = {
-  doFetchMoreProducts: fetchMoreProducts,
+  doFetchObjects: fetchObjects,
   doSyncRepos: syncRepos,
 };
 

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -34,9 +34,10 @@ import Login from '@/components/user/login';
 import { PrivateRoute } from '@/components/utils';
 import initializeI18n from '@/i18n';
 import reducer from '@/store';
+import { fetchObjects } from '@/store/actions';
 import { clearErrors } from '@/store/errors/actions';
-import { fetchProducts } from '@/store/products/actions';
 import { login, refetchAllData } from '@/store/user/actions';
+import { OBJECT_TYPES } from '@/utils/constants';
 import { log, logError } from '@/utils/logging';
 import routes, { routePatterns } from '@/utils/routes';
 import { createSocket } from '@/utils/websockets';
@@ -175,7 +176,7 @@ initializeI18n((i18nError?: string) => {
     // If logged in, fetch products before rendering App
     if (user) {
       (appStore.dispatch as ThunkDispatch<any, void, AnyAction>)(
-        fetchProducts(),
+        fetchObjects({ objectType: OBJECT_TYPES.PRODUCT, reset: true }),
       ).finally(renderApp);
     } else {
       renderApp();

--- a/src/js/store/actions.ts
+++ b/src/js/store/actions.ts
@@ -1,0 +1,123 @@
+import { ThunkResult } from '@/store';
+import apiFetch, { addUrlParams } from '@/utils/api';
+import { ObjectTypes } from '@/utils/constants';
+
+interface ObjectPayload {
+  objectType: ObjectTypes;
+  url: string;
+  reset?: boolean;
+}
+interface ObjectFilters {
+  slug: string;
+}
+interface FetchObjectsStarted {
+  type: 'FETCH_OBJECTS_STARTED';
+  payload: ObjectPayload;
+}
+interface FetchObjectsSucceeded {
+  type: 'FETCH_OBJECTS_SUCCEEDED';
+  payload: {
+    response: { next: string | null; results: any[] };
+  } & ObjectPayload;
+}
+interface FetchObjectsFailed {
+  type: 'FETCH_OBJECTS_FAILED';
+  payload: ObjectPayload;
+}
+interface FetchObjectStarted {
+  type: 'FETCH_OBJECT_STARTED';
+  payload: { filters: ObjectFilters } & ObjectPayload;
+}
+interface FetchObjectSucceeded {
+  type: 'FETCH_OBJECT_SUCCEEDED';
+  payload: { object: any; filters: ObjectFilters } & ObjectPayload;
+}
+interface FetchObjectFailed {
+  type: 'FETCH_OBJECT_FAILED';
+  payload: { filters: ObjectFilters } & ObjectPayload;
+}
+
+export type ObjectsAction =
+  | FetchObjectsStarted
+  | FetchObjectsSucceeded
+  | FetchObjectsFailed
+  | FetchObjectStarted
+  | FetchObjectSucceeded
+  | FetchObjectFailed;
+
+export type ObjectsActionType = ({
+  objectType,
+  url,
+  reset,
+  filters,
+}: {
+  objectType: ObjectTypes;
+  url?: string;
+  reset?: boolean;
+  filters?: ObjectFilters;
+}) => Promise<any>;
+
+export const fetchObjects = ({
+  objectType,
+  url,
+  reset = false,
+}: {
+  objectType: ObjectTypes;
+  url?: string;
+  reset?: boolean;
+}): ThunkResult => async dispatch => {
+  const baseUrl = url || window.api_urls[`${objectType}_list`]();
+  dispatch({
+    type: 'FETCH_OBJECTS_STARTED',
+    payload: { objectType, url: baseUrl, reset },
+  });
+  try {
+    const response = await apiFetch(baseUrl, dispatch);
+    return dispatch({
+      type: 'FETCH_OBJECTS_SUCCEEDED',
+      payload: { response, objectType, url: baseUrl, reset },
+    });
+  } catch (err) {
+    dispatch({
+      type: 'FETCH_OBJECTS_FAILED',
+      payload: { objectType, url: baseUrl, reset },
+    });
+    throw err;
+  }
+};
+
+export const fetchObject = ({
+  objectType,
+  url,
+  filters,
+}: {
+  objectType: ObjectTypes;
+  url?: string;
+  filters?: ObjectFilters;
+}): ThunkResult => async dispatch => {
+  const baseUrl = url || window.api_urls[`${objectType}_list`]();
+  dispatch({
+    type: 'FETCH_OBJECT_STARTED',
+    payload: { objectType, url: baseUrl, filters },
+  });
+  try {
+    const response = await apiFetch(
+      addUrlParams(baseUrl, { ...filters }),
+      dispatch,
+    );
+    const object =
+      response && response.results && response.results.length
+        ? response.results[0]
+        : null;
+    return dispatch({
+      type: 'FETCH_OBJECT_SUCCEEDED',
+      payload: { object, filters, objectType, url: baseUrl },
+    });
+  } catch (err) {
+    dispatch({
+      type: 'FETCH_OBJECT_FAILED',
+      payload: { filters, objectType, url: baseUrl },
+    });
+    throw err;
+  }
+};

--- a/src/js/store/products/actions.ts
+++ b/src/js/store/products/actions.ts
@@ -1,44 +1,8 @@
 import { ThunkResult } from '@/store';
-import { Product } from '@/store/products/reducer';
-import apiFetch, { addUrlParams } from '@/utils/api';
+import { fetchObjects } from '@/store/actions';
+import apiFetch from '@/utils/api';
+import { OBJECT_TYPES } from '@/utils/constants';
 
-interface FetchProductsStarted {
-  type: 'FETCH_PRODUCTS_STARTED';
-}
-interface FetchProductsSucceeded {
-  type: 'FETCH_PRODUCTS_SUCCEEDED';
-  payload: { next: string | null; results: Product[] };
-}
-interface FetchProductsFailed {
-  type: 'FETCH_PRODUCTS_FAILED';
-}
-interface FetchMoreProductsStarted {
-  type: 'FETCH_MORE_PRODUCTS_STARTED';
-  payload: { url: string };
-}
-interface FetchMoreProductsSucceeded {
-  type: 'FETCH_MORE_PRODUCTS_SUCCEEDED';
-  payload: { next: string | null; results: Product[] };
-}
-interface FetchMoreProductsFailed {
-  type: 'FETCH_MORE_PRODUCTS_FAILED';
-  payload: { url: string };
-}
-interface ProductFilters {
-  slug: string;
-}
-interface FetchProductStarted {
-  type: 'FETCH_PRODUCT_STARTED';
-  payload: ProductFilters;
-}
-interface FetchProductSucceeded {
-  type: 'FETCH_PRODUCT_SUCCEEDED';
-  payload: { product: Product | null } & ProductFilters;
-}
-interface FetchProductFailed {
-  type: 'FETCH_PRODUCT_FAILED';
-  payload: ProductFilters;
-}
 interface SyncReposStarted {
   type: 'SYNC_REPOS_STARTED';
 }
@@ -50,75 +14,9 @@ interface SyncReposFailed {
 }
 
 export type ProductsAction =
-  | FetchProductsStarted
-  | FetchProductsSucceeded
-  | FetchProductsFailed
-  | FetchMoreProductsStarted
-  | FetchMoreProductsSucceeded
-  | FetchMoreProductsFailed
-  | FetchProductStarted
-  | FetchProductSucceeded
-  | FetchProductFailed
   | SyncReposStarted
   | SyncReposSucceeded
   | SyncReposFailed;
-
-export const fetchProducts = (): ThunkResult => async dispatch => {
-  dispatch({ type: 'FETCH_PRODUCTS_STARTED' });
-  const baseUrl = window.api_urls.product_list();
-  try {
-    const response = await apiFetch(baseUrl, dispatch);
-    return dispatch({
-      type: 'FETCH_PRODUCTS_SUCCEEDED',
-      payload: response,
-    });
-  } catch (err) {
-    dispatch({ type: 'FETCH_PRODUCTS_FAILED' });
-    throw err;
-  }
-};
-
-export const fetchMoreProducts = ({
-  url,
-}: {
-  url: string;
-}): ThunkResult => async dispatch => {
-  dispatch({ type: 'FETCH_MORE_PRODUCTS_STARTED', payload: { url } });
-  try {
-    const response = await apiFetch(url, dispatch);
-    return dispatch({
-      type: 'FETCH_MORE_PRODUCTS_SUCCEEDED',
-      payload: response,
-    });
-  } catch (err) {
-    dispatch({ type: 'FETCH_MORE_PRODUCTS_FAILED', payload: { url } });
-    throw err;
-  }
-};
-
-export const fetchProduct = (
-  filters: ProductFilters,
-): ThunkResult => async dispatch => {
-  dispatch({ type: 'FETCH_PRODUCT_STARTED', payload: filters });
-  const baseUrl = window.api_urls.product_list();
-  try {
-    const response = await apiFetch(
-      addUrlParams(baseUrl, { ...filters }),
-      dispatch,
-    );
-    const product =
-      response && response.results && response.results.length
-        ? response.results[0]
-        : null;
-    return dispatch({
-      type: 'FETCH_PRODUCT_SUCCEEDED',
-      payload: { ...filters, product },
-    });
-  } catch (err) {
-    dispatch({ type: 'FETCH_PRODUCT_FAILED', payload: filters });
-    throw err;
-  }
-};
 
 export const syncRepos = (): ThunkResult => async dispatch => {
   dispatch({ type: 'SYNC_REPOS_STARTED' });
@@ -127,7 +25,9 @@ export const syncRepos = (): ThunkResult => async dispatch => {
       method: 'POST',
     });
     dispatch({ type: 'SYNC_REPOS_SUCCEEDED' });
-    return dispatch(fetchProducts());
+    return dispatch(
+      fetchObjects({ objectType: OBJECT_TYPES.PRODUCT, reset: true }),
+    );
   } catch (err) {
     dispatch({ type: 'SYNC_REPOS_FAILED' });
     throw err;

--- a/src/js/store/products/reducer.ts
+++ b/src/js/store/products/reducer.ts
@@ -1,5 +1,7 @@
+import { ObjectsAction } from '@/store/actions';
 import { ProductsAction } from '@/store/products/actions';
 import { LogoutAction } from '@/store/user/actions';
+import { OBJECT_TYPES } from '@/utils/constants';
 
 export interface Product {
   id: string;
@@ -24,39 +26,51 @@ const defaultState = {
 
 const reducer = (
   products: ProductsState = defaultState,
-  action: ProductsAction | LogoutAction,
+  action: ProductsAction | ObjectsAction | LogoutAction,
 ): ProductsState => {
   switch (action.type) {
     case 'USER_LOGGED_OUT':
       return { ...defaultState };
-    case 'FETCH_PRODUCTS_SUCCEEDED': {
-      const { results, next } = action.payload;
-      return {
-        ...products,
-        products: results,
-        next,
-      };
-    }
-    case 'FETCH_MORE_PRODUCTS_SUCCEEDED': {
-      const { results, next } = action.payload;
-      // Store list of known product IDs to filter out duplicates
-      const ids = products.products.map(p => p.id);
-      return {
-        ...products,
-        products: [
-          ...products.products,
-          ...results.filter(p => !ids.includes(p.id)),
-        ],
-        next,
-      };
-    }
-    case 'FETCH_PRODUCT_SUCCEEDED': {
-      const { product, slug } = action.payload;
-      if (!product) {
-        return { ...products, notFound: [...products.notFound, slug] };
+    case 'FETCH_OBJECTS_SUCCEEDED': {
+      const {
+        response: { results, next },
+        objectType,
+        reset,
+      } = action.payload;
+      if (objectType === OBJECT_TYPES.PRODUCT) {
+        if (reset) {
+          return {
+            ...products,
+            products: results,
+            next,
+          };
+        }
+        // Store list of known product IDs to filter out duplicates
+        const ids = products.products.map(p => p.id);
+        return {
+          ...products,
+          products: [
+            ...products.products,
+            ...results.filter(p => !ids.includes(p.id)),
+          ],
+          next,
+        };
       }
-      if (!products.products.find(p => p.id === product.id)) {
-        return { ...products, products: [...products.products, product] };
+      return products;
+    }
+    case 'FETCH_OBJECT_SUCCEEDED': {
+      const {
+        object,
+        filters: { slug },
+        objectType,
+      } = action.payload;
+      if (objectType === OBJECT_TYPES.PRODUCT) {
+        if (!object) {
+          return { ...products, notFound: [...products.notFound, slug] };
+        }
+        if (!products.products.find(p => p.id === object.id)) {
+          return { ...products, products: [...products.products, object] };
+        }
       }
       return products;
     }

--- a/src/js/store/user/actions.ts
+++ b/src/js/store/user/actions.ts
@@ -1,7 +1,8 @@
 import { ThunkResult } from '@/store';
-import { fetchProducts } from '@/store/products/actions';
+import { fetchObjects } from '@/store/actions';
 import { User } from '@/store/user/reducer';
 import apiFetch from '@/utils/api';
+import { OBJECT_TYPES } from '@/utils/constants';
 
 interface LoginAction {
   type: 'USER_LOGGED_IN';
@@ -62,7 +63,9 @@ export const refetchAllData = (): ThunkResult => async dispatch => {
       return dispatch({ type: 'USER_LOGGED_OUT' });
     }
     dispatch(login(payload));
-    return dispatch(fetchProducts());
+    return dispatch(
+      fetchObjects({ objectType: OBJECT_TYPES.PRODUCT, reset: true }),
+    );
   } catch (err) {
     dispatch({ type: 'REFETCH_DATA_FAILED' });
     throw err;

--- a/src/js/utils/constants.ts
+++ b/src/js/utils/constants.ts
@@ -1,0 +1,5 @@
+export type ObjectTypes = 'product';
+
+export const OBJECT_TYPES = {
+  PRODUCT: 'product' as 'product',
+};

--- a/test/js/components/products/detail.test.jsx
+++ b/test/js/components/products/detail.test.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { StaticRouter } from 'react-router-dom';
 
 import ProductDetail from '@/components/products/detail';
-import { fetchProduct } from '@/store/products/actions';
+import { fetchObject } from '@/store/actions';
 import routes from '@/utils/routes';
 
-jest.mock('@/store/products/actions');
+jest.mock('@/store/actions');
 
-fetchProduct.mockReturnValue({ type: 'TEST' });
+fetchObject.mockReturnValue({ type: 'TEST' });
 
 afterEach(() => {
-  fetchProduct.mockClear();
+  fetchObject.mockClear();
 });
 
 import { renderWithRedux, storeWithApi } from './../../utils';
@@ -63,8 +63,9 @@ describe('<ProductList />', () => {
       const { queryByText } = setup({ productSlug: 'other-product' });
 
       expect(queryByText('Product 1')).toBeNull();
-      expect(fetchProduct).toHaveBeenCalledWith({
-        slug: 'other-product',
+      expect(fetchObject).toHaveBeenCalledWith({
+        filters: { slug: 'other-product' },
+        objectType: 'product',
       });
     });
   });

--- a/test/js/components/products/list.test.jsx
+++ b/test/js/components/products/list.test.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import ProductList from '@/components/products/list';
-import { fetchMoreProducts, syncRepos } from '@/store/products/actions';
+import { fetchObjects } from '@/store/actions';
+import { syncRepos } from '@/store/products/actions';
 
 import { renderWithRedux, storeWithApi } from './../../utils';
 
@@ -13,12 +14,13 @@ jest.mock('react-fns', () => ({
     return props => <Component x={0} y={0} {...props} />;
   },
 }));
+jest.mock('@/store/actions');
 jest.mock('@/store/products/actions');
-fetchMoreProducts.mockReturnValue(() => Promise.resolve({ type: 'TEST' }));
+fetchObjects.mockReturnValue(() => Promise.resolve({ type: 'TEST' }));
 syncRepos.mockReturnValue(() => Promise.resolve({ type: 'TEST' }));
 
 afterEach(() => {
-  fetchMoreProducts.mockClear();
+  fetchObjects.mockClear();
   syncRepos.mockClear();
 });
 
@@ -101,8 +103,9 @@ describe('<ProductList />', () => {
       setup(initialState, { y: 1000 }, rerender);
 
       expect(getByText('Loading…')).toBeVisible();
-      expect(fetchMoreProducts).toHaveBeenCalledWith({
+      expect(fetchObjects).toHaveBeenCalledWith({
         url: 'next-url',
+        objectType: 'product',
       });
     });
 
@@ -119,7 +122,7 @@ describe('<ProductList />', () => {
       setup(state, { y: 1000 }, rerender);
 
       expect(queryByText('Loading…')).toBeNull();
-      expect(fetchMoreProducts).not.toHaveBeenCalled();
+      expect(fetchObjects).not.toHaveBeenCalled();
     });
   });
 

--- a/test/js/store/actions.test.js
+++ b/test/js/store/actions.test.js
@@ -1,0 +1,241 @@
+import fetchMock from 'fetch-mock';
+
+import * as actions from '@/store/actions';
+import { addUrlParams } from '@/utils/api';
+
+import { storeWithApi } from './../utils';
+
+describe('fetchObjects with `reset: true`', () => {
+  let url, objectPayload;
+
+  beforeAll(() => {
+    url = window.api_urls.product_list();
+    objectPayload = {
+      objectType: 'product',
+      url,
+      reset: true,
+    };
+  });
+
+  describe('success', () => {
+    test('GETs products from api', () => {
+      const store = storeWithApi({});
+      const product = {
+        id: 'p1',
+        name: 'Product 1',
+        slug: 'product-1',
+        description: 'This is a test product.',
+        repo_url: 'http://www.test.test',
+      };
+      const response = { next: null, results: [product] };
+      fetchMock.getOnce(url, response);
+      const started = {
+        type: 'FETCH_OBJECTS_STARTED',
+        payload: objectPayload,
+      };
+      const succeeded = {
+        type: 'FETCH_OBJECTS_SUCCEEDED',
+        payload: { response, ...objectPayload },
+      };
+
+      expect.assertions(1);
+      return store
+        .dispatch(actions.fetchObjects({ objectType: 'product', reset: true }))
+        .then(() => {
+          expect(store.getActions()).toEqual([started, succeeded]);
+        });
+    });
+  });
+
+  describe('error', () => {
+    test('dispatches FETCH_OBJECTS_FAILED action', () => {
+      const store = storeWithApi({});
+      fetchMock.getOnce(url, {
+        status: 500,
+        body: {},
+      });
+      const started = {
+        type: 'FETCH_OBJECTS_STARTED',
+        payload: objectPayload,
+      };
+      const failed = {
+        type: 'FETCH_OBJECTS_FAILED',
+        payload: objectPayload,
+      };
+
+      expect.assertions(5);
+      return store
+        .dispatch(actions.fetchObjects({ objectType: 'product', reset: true }))
+        .catch(() => {
+          const allActions = store.getActions();
+
+          expect(allActions[0]).toEqual(started);
+          expect(allActions[1].type).toEqual('ERROR_ADDED');
+          expect(allActions[1].payload.message).toEqual(
+            'Internal Server Error',
+          );
+          expect(allActions[2]).toEqual(failed);
+          expect(window.console.error).toHaveBeenCalled();
+        });
+    });
+  });
+});
+
+describe('fetchObjects with `reset: false`', () => {
+  let url, objectPayload;
+
+  beforeAll(() => {
+    const baseUrl = window.api_urls.product_list();
+    const filters = { page: 2 };
+    url = addUrlParams(baseUrl, filters);
+    objectPayload = {
+      objectType: 'product',
+      url,
+      reset: false,
+    };
+  });
+
+  describe('success', () => {
+    test('GETs next products page', () => {
+      const store = storeWithApi({});
+      const nextProducts = [{ id: 'p2', name: 'Product 2', slug: 'product-2' }];
+      const mockResponse = {
+        next: null,
+        results: nextProducts,
+      };
+      fetchMock.getOnce(url, mockResponse);
+      const started = {
+        type: 'FETCH_OBJECTS_STARTED',
+        payload: objectPayload,
+      };
+      const succeeded = {
+        type: 'FETCH_OBJECTS_SUCCEEDED',
+        payload: { response: mockResponse, ...objectPayload },
+      };
+
+      expect.assertions(1);
+      return store
+        .dispatch(actions.fetchObjects({ url, objectType: 'product' }))
+        .then(() => {
+          expect(store.getActions()).toEqual([started, succeeded]);
+        });
+    });
+  });
+
+  describe('error', () => {
+    test('dispatches FETCH_OBJECTS_FAILED action', () => {
+      const store = storeWithApi({});
+      fetchMock.getOnce(url, { status: 500, body: 'Oops.' });
+      const started = {
+        type: 'FETCH_OBJECTS_STARTED',
+        payload: objectPayload,
+      };
+      const failed = {
+        type: 'FETCH_OBJECTS_FAILED',
+        payload: objectPayload,
+      };
+
+      expect.assertions(5);
+      return store
+        .dispatch(actions.fetchObjects({ url, objectType: 'product' }))
+        .catch(() => {
+          const allActions = store.getActions();
+
+          expect(allActions[0]).toEqual(started);
+          expect(allActions[1].type).toEqual('ERROR_ADDED');
+          expect(allActions[1].payload.message).toEqual('Oops.');
+          expect(allActions[2]).toEqual(failed);
+          expect(window.console.error).toHaveBeenCalled();
+        });
+    });
+  });
+});
+
+describe('fetchObject', () => {
+  let url, objectPayload;
+
+  beforeAll(() => {
+    url = window.api_urls.product_list();
+    objectPayload = {
+      objectType: 'product',
+      url,
+    };
+  });
+
+  describe('success', () => {
+    test('GETs product from api', () => {
+      const store = storeWithApi({});
+      const filters = { slug: 'product-1' };
+      const product = { id: 'p1', name: 'Product 1', slug: 'product-1' };
+      fetchMock.getOnce(addUrlParams(url, filters), { results: [product] });
+      const started = {
+        type: 'FETCH_OBJECT_STARTED',
+        payload: { filters, ...objectPayload },
+      };
+      const succeeded = {
+        type: 'FETCH_OBJECT_SUCCEEDED',
+        payload: { filters, object: product, ...objectPayload },
+      };
+
+      expect.assertions(1);
+      return store
+        .dispatch(actions.fetchObject({ objectType: 'product', filters }))
+        .then(() => {
+          expect(store.getActions()).toEqual([started, succeeded]);
+        });
+    });
+
+    test('stores null if no product returned from api', () => {
+      const store = storeWithApi({});
+      const filters = { slug: 'product-1' };
+      fetchMock.getOnce(addUrlParams(url, filters), 404);
+      const started = {
+        type: 'FETCH_OBJECT_STARTED',
+        payload: { filters, ...objectPayload },
+      };
+      const succeeded = {
+        type: 'FETCH_OBJECT_SUCCEEDED',
+        payload: { filters, object: null, ...objectPayload },
+      };
+
+      expect.assertions(1);
+      return store
+        .dispatch(actions.fetchObject({ objectType: 'product', filters }))
+        .then(() => {
+          expect(store.getActions()).toEqual([started, succeeded]);
+        });
+    });
+  });
+
+  describe('error', () => {
+    test('dispatches FETCH_OBJECT_FAILED action', () => {
+      const store = storeWithApi({});
+      const filters = { slug: 'product-1' };
+      fetchMock.getOnce(addUrlParams(url, filters), {
+        status: 500,
+        body: { detail: 'Nope.' },
+      });
+      const started = {
+        type: 'FETCH_OBJECT_STARTED',
+        payload: { filters, ...objectPayload },
+      };
+      const failed = {
+        type: 'FETCH_OBJECT_FAILED',
+        payload: { filters, ...objectPayload },
+      };
+
+      expect.assertions(5);
+      return store
+        .dispatch(actions.fetchObject({ objectType: 'product', filters }))
+        .catch(() => {
+          const allActions = store.getActions();
+
+          expect(allActions[0]).toEqual(started);
+          expect(allActions[1].type).toEqual('ERROR_ADDED');
+          expect(allActions[1].payload.message).toEqual('Nope.');
+          expect(allActions[2]).toEqual(failed);
+          expect(window.console.error).toHaveBeenCalled();
+        });
+    });
+  });
+});

--- a/test/js/store/products/actions.test.js
+++ b/test/js/store/products/actions.test.js
@@ -1,210 +1,24 @@
 import fetchMock from 'fetch-mock';
 
 import * as actions from '@/store/products/actions';
-import { addUrlParams } from '@/utils/api';
 
 import { storeWithApi } from './../../utils';
 
-describe('fetchProducts', () => {
-  describe('success', () => {
-    test('GETs products from api', () => {
-      const store = storeWithApi({});
-      const product = {
-        id: 'p1',
-        name: 'Product 1',
-        slug: 'product-1',
-        description: 'This is a test product.',
-        repo_url: 'http://www.test.test',
-      };
-      const response = { next: null, results: [product] };
-      fetchMock.getOnce(window.api_urls.product_list(), response);
-      const started = {
-        type: 'FETCH_PRODUCTS_STARTED',
-      };
-      const succeeded = {
-        type: 'FETCH_PRODUCTS_SUCCEEDED',
-        payload: response,
-      };
-
-      expect.assertions(1);
-      return store.dispatch(actions.fetchProducts()).then(() => {
-        expect(store.getActions()).toEqual([started, succeeded]);
-      });
-    });
-  });
-
-  describe('error', () => {
-    test('dispatches FETCH_PRODUCTS_FAILED action', () => {
-      const store = storeWithApi({});
-      fetchMock.getOnce(window.api_urls.product_list(), {
-        status: 500,
-        body: {},
-      });
-      const started = {
-        type: 'FETCH_PRODUCTS_STARTED',
-      };
-      const failed = {
-        type: 'FETCH_PRODUCTS_FAILED',
-      };
-
-      expect.assertions(5);
-      return store.dispatch(actions.fetchProducts()).catch(() => {
-        const allActions = store.getActions();
-
-        expect(allActions[0]).toEqual(started);
-        expect(allActions[1].type).toEqual('ERROR_ADDED');
-        expect(allActions[1].payload.message).toEqual('Internal Server Error');
-        expect(allActions[2]).toEqual(failed);
-        expect(window.console.error).toHaveBeenCalled();
-      });
-    });
-  });
-});
-
-describe('fetchMoreProducts', () => {
-  let url;
-
-  beforeAll(() => {
-    const baseUrl = window.api_urls.product_list();
-    const filters = { page: 2 };
-    url = addUrlParams(baseUrl, filters);
-  });
-
-  describe('success', () => {
-    test('GETs next products page', () => {
-      const store = storeWithApi({});
-      const nextProducts = [{ id: 'p2', name: 'Product 2', slug: 'product-2' }];
-      const mockResponse = {
-        next: null,
-        results: nextProducts,
-      };
-      fetchMock.getOnce(url, mockResponse);
-      const started = {
-        type: 'FETCH_MORE_PRODUCTS_STARTED',
-        payload: { url },
-      };
-      const succeeded = {
-        type: 'FETCH_MORE_PRODUCTS_SUCCEEDED',
-        payload: mockResponse,
-      };
-
-      expect.assertions(1);
-      return store.dispatch(actions.fetchMoreProducts({ url })).then(() => {
-        expect(store.getActions()).toEqual([started, succeeded]);
-      });
-    });
-  });
-
-  describe('error', () => {
-    test('dispatches FETCH_MORE_PRODUCTS_FAILED action', () => {
-      const store = storeWithApi({});
-      fetchMock.getOnce(url, { status: 500, body: 'Oops.' });
-      const started = {
-        type: 'FETCH_MORE_PRODUCTS_STARTED',
-        payload: { url },
-      };
-      const failed = {
-        type: 'FETCH_MORE_PRODUCTS_FAILED',
-        payload: { url },
-      };
-
-      expect.assertions(5);
-      return store.dispatch(actions.fetchMoreProducts({ url })).catch(() => {
-        const allActions = store.getActions();
-
-        expect(allActions[0]).toEqual(started);
-        expect(allActions[1].type).toEqual('ERROR_ADDED');
-        expect(allActions[1].payload.message).toEqual('Oops.');
-        expect(allActions[2]).toEqual(failed);
-        expect(window.console.error).toHaveBeenCalled();
-      });
-    });
-  });
-});
-
-describe('fetchProduct', () => {
-  let baseUrl;
-
-  beforeAll(() => {
-    baseUrl = window.api_urls.product_list();
-  });
-
-  describe('success', () => {
-    test('GETs product from api', () => {
-      const store = storeWithApi({});
-      const filters = { slug: 'product-1' };
-      const product = { id: 'p1', name: 'Product 1', slug: 'product-1' };
-      fetchMock.getOnce(addUrlParams(baseUrl, filters), { results: [product] });
-      const started = {
-        type: 'FETCH_PRODUCT_STARTED',
-        payload: filters,
-      };
-      const succeeded = {
-        type: 'FETCH_PRODUCT_SUCCEEDED',
-        payload: { ...filters, product },
-      };
-
-      expect.assertions(1);
-      return store.dispatch(actions.fetchProduct(filters)).then(() => {
-        expect(store.getActions()).toEqual([started, succeeded]);
-      });
-    });
-
-    test('stores null if no product returned from api', () => {
-      const store = storeWithApi({});
-      const filters = { slug: 'product-1' };
-      fetchMock.getOnce(addUrlParams(baseUrl, filters), 404);
-      const started = {
-        type: 'FETCH_PRODUCT_STARTED',
-        payload: filters,
-      };
-      const succeeded = {
-        type: 'FETCH_PRODUCT_SUCCEEDED',
-        payload: { ...filters, product: null },
-      };
-
-      expect.assertions(1);
-      return store.dispatch(actions.fetchProduct(filters)).then(() => {
-        expect(store.getActions()).toEqual([started, succeeded]);
-      });
-    });
-  });
-
-  describe('error', () => {
-    test('dispatches FETCH_PRODUCT_FAILED action', () => {
-      const store = storeWithApi({});
-      const filters = { slug: 'product-1' };
-      fetchMock.getOnce(addUrlParams(baseUrl, filters), {
-        status: 500,
-        body: { detail: 'Nope.' },
-      });
-      const started = {
-        type: 'FETCH_PRODUCT_STARTED',
-        payload: filters,
-      };
-      const failed = {
-        type: 'FETCH_PRODUCT_FAILED',
-        payload: filters,
-      };
-
-      expect.assertions(5);
-      return store.dispatch(actions.fetchProduct(filters)).catch(() => {
-        const allActions = store.getActions();
-
-        expect(allActions[0]).toEqual(started);
-        expect(allActions[1].type).toEqual('ERROR_ADDED');
-        expect(allActions[1].payload.message).toEqual('Nope.');
-        expect(allActions[2]).toEqual(failed);
-        expect(window.console.error).toHaveBeenCalled();
-      });
-    });
-  });
-});
-
 describe('syncRepos', () => {
+  let url, objectPayload;
+
+  beforeAll(() => {
+    url = window.api_urls.product_list();
+    objectPayload = {
+      objectType: 'product',
+      url,
+      reset: true,
+    };
+  });
+
   test('dispatches SyncRepos action and fetches products', () => {
     const store = storeWithApi({});
-    fetchMock.getOnce(window.api_urls.product_list(), {
+    fetchMock.getOnce(url, {
       next: null,
       results: [],
     });
@@ -219,11 +33,15 @@ describe('syncRepos', () => {
       type: 'SYNC_REPOS_SUCCEEDED',
     };
     const started = {
-      type: 'FETCH_PRODUCTS_STARTED',
+      type: 'FETCH_OBJECTS_STARTED',
+      payload: objectPayload,
     };
     const succeeded = {
-      type: 'FETCH_PRODUCTS_SUCCEEDED',
-      payload: { next: null, results: [] },
+      type: 'FETCH_OBJECTS_SUCCEEDED',
+      payload: {
+        response: { next: null, results: [] },
+        ...objectPayload,
+      },
     };
 
     expect.assertions(1);
@@ -238,7 +56,7 @@ describe('syncRepos', () => {
   });
 
   describe('error', () => {
-    test('dispatches FETCH_PRODUCT_FAILED action', () => {
+    test('dispatches SYNC_REPOS_FAILED action', () => {
       const store = storeWithApi({});
       fetchMock.postOnce(window.api_urls.user_refresh(), {
         status: 500,

--- a/test/js/store/products/reducer.test.js
+++ b/test/js/store/products/reducer.test.js
@@ -24,61 +24,90 @@ describe('reducer', () => {
     expect(actual).toEqual(expected);
   });
 
-  test('handles FETCH_PRODUCTS_SUCCEEDED action', () => {
-    const product1 = {
-      id: 'p1',
-      slug: 'product-1',
-      name: 'Product 1',
-      description: 'This is a test product.',
-    };
-    const product2 = {
-      id: 'p2',
-      slug: 'product-2',
-      name: 'Product 2',
-      description: 'This is another test product.',
-    };
-    const expected = { products: [product2], next: 'next-url' };
-    const actual = reducer(
-      { products: [product1], next: null },
-      {
-        type: 'FETCH_PRODUCTS_SUCCEEDED',
-        payload: { results: [product2], next: 'next-url' },
-      },
-    );
-
-    expect(actual).toEqual(expected);
-  });
-
-  describe('FETCH_MORE_PRODUCTS_SUCCEEDED action', () => {
-    const mockProducts = {
-      notFound: [],
-      products: [
+  describe('FETCH_OBJECTS_SUCCEEDED', () => {
+    test('resets products list if `reset: true`', () => {
+      const product1 = {
+        id: 'p1',
+        slug: 'product-1',
+        name: 'Product 1',
+        description: 'This is a test product.',
+      };
+      const product2 = {
+        id: 'p2',
+        slug: 'product-2',
+        name: 'Product 2',
+        description: 'This is another test product.',
+      };
+      const expected = { products: [product2], next: 'next-url' };
+      const actual = reducer(
+        { products: [product1], next: null },
         {
-          id: 'product1',
-          slug: 'product-1',
-          name: 'Product 1',
+          type: 'FETCH_OBJECTS_SUCCEEDED',
+          payload: {
+            response: { results: [product2], next: 'next-url' },
+            objectType: 'product',
+            reset: true,
+          },
         },
-      ],
-      next: null,
-    };
-    const fetchedProduct = {
-      id: 'product2',
-      slug: 'product-2',
-      name: 'Product 2',
-    };
-    const expected = {
-      ...mockProducts,
-      products: [...mockProducts.products, fetchedProduct],
-    };
-    const actual = reducer(mockProducts, {
-      type: 'FETCH_MORE_PRODUCTS_SUCCEEDED',
-      payload: { results: [fetchedProduct], next: null },
+      );
+
+      expect(actual).toEqual(expected);
     });
 
-    expect(actual).toEqual(expected);
+    test('adds to products list if `reset: false`', () => {
+      const mockProducts = {
+        notFound: [],
+        products: [
+          {
+            id: 'product1',
+            slug: 'product-1',
+            name: 'Product 1',
+          },
+        ],
+        next: null,
+      };
+      const fetchedProduct = {
+        id: 'product2',
+        slug: 'product-2',
+        name: 'Product 2',
+      };
+      const expected = {
+        ...mockProducts,
+        products: [...mockProducts.products, fetchedProduct],
+      };
+      const actual = reducer(mockProducts, {
+        type: 'FETCH_OBJECTS_SUCCEEDED',
+        payload: {
+          response: { results: [fetchedProduct], next: null },
+          objectType: 'product',
+          reset: false,
+        },
+      });
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('ignores if objectType !== "product"', () => {
+      const product = {
+        id: 'p1',
+        slug: 'product-1',
+        name: 'Product 1',
+      };
+      const expected = { products: [product], next: 'next-url' };
+      const actual = reducer(expected, {
+        type: 'FETCH_OBJECTS_SUCCEEDED',
+        payload: {
+          response: { results: [], next: null },
+          objectType: 'other-object',
+          reset: true,
+        },
+      });
+
+      expect(actual).toEqual(expected);
+    });
   });
 
-  describe('FETCH_PRODUCT_SUCCEEDED', () => {
+  describe('FETCH_OBJECT_SUCCEEDED', () => {
     test('adds product', () => {
       const product1 = {
         id: 'p1',
@@ -94,8 +123,12 @@ describe('reducer', () => {
       const actual = reducer(
         { products: [product1] },
         {
-          type: 'FETCH_PRODUCT_SUCCEEDED',
-          payload: { product: product2 },
+          type: 'FETCH_OBJECT_SUCCEEDED',
+          payload: {
+            object: product2,
+            filters: { slug: 'product-2' },
+            objectType: 'product',
+          },
         },
       );
 
@@ -115,8 +148,12 @@ describe('reducer', () => {
       const actual = reducer(
         { products: [product1], notFound: ['product-2'] },
         {
-          type: 'FETCH_PRODUCT_SUCCEEDED',
-          payload: { product: null, slug: 'product-3' },
+          type: 'FETCH_OBJECT_SUCCEEDED',
+          payload: {
+            object: null,
+            filters: { slug: 'product-3' },
+            objectType: 'product',
+          },
         },
       );
 
@@ -134,8 +171,36 @@ describe('reducer', () => {
         notFound: ['product-2'],
       };
       const actual = reducer(expected, {
-        type: 'FETCH_PRODUCT_SUCCEEDED',
-        payload: { product: product1, slug: 'product-1' },
+        type: 'FETCH_OBJECT_SUCCEEDED',
+        payload: {
+          object: product1,
+          filters: { slug: 'product-1' },
+          objectType: 'product',
+        },
+      });
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('ignores if objectType !== "product"', () => {
+      const product = {
+        id: 'p1',
+        slug: 'product-1',
+        name: 'Product 1',
+      };
+      const product2 = {
+        id: 'p2',
+        slug: 'product-2',
+        name: 'Product 2',
+      };
+      const expected = { products: [product], next: null };
+      const actual = reducer(expected, {
+        type: 'FETCH_OBJECT_SUCCEEDED',
+        payload: {
+          object: product2,
+          filters: { slug: 'product-2' },
+          objectType: 'other-object',
+        },
       });
 
       expect(actual).toEqual(expected);

--- a/test/js/store/user/actions.test.js
+++ b/test/js/store/user/actions.test.js
@@ -121,6 +121,17 @@ describe('logout', () => {
 });
 
 describe('refetchAllData', () => {
+  let url, objectPayload;
+
+  beforeAll(() => {
+    url = window.api_urls.product_list();
+    objectPayload = {
+      objectType: 'product',
+      url,
+      reset: true,
+    };
+  });
+
   describe('success', () => {
     test('GETs user from api', () => {
       const store = storeWithApi({});
@@ -140,13 +151,17 @@ describe('refetchAllData', () => {
         repo_url: 'http://www.test.test',
       };
       const response = { next: null, results: [product] };
-      fetchMock.getOnce(window.api_urls.product_list(), response);
+      fetchMock.getOnce(url, response);
       const productsStarted = {
-        type: 'FETCH_PRODUCTS_STARTED',
+        type: 'FETCH_OBJECTS_STARTED',
+        payload: objectPayload,
       };
       const productsSucceeded = {
-        type: 'FETCH_PRODUCTS_SUCCEEDED',
-        payload: response,
+        type: 'FETCH_OBJECTS_SUCCEEDED',
+        payload: {
+          response,
+          ...objectPayload,
+        },
       };
 
       expect.assertions(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,9 +964,9 @@
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@testing-library/dom@^5.0.0":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.5.1.tgz#ac6a5244b8b7af3e7000834abf1f79d26cdcdd1d"
-  integrity sha512-FEKxR51dCBixz8WoIlTHJucLYlVSZ4oMaWcnbID8SKRy+07JNACwUDHzpeeQv0853Hme91niHnvNebwGWZu21w==
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.5.2.tgz#8adc02bbfd70bd2b647aca63badc86e8fe3b24e7"
+  integrity sha512-7Yrpqr67sN/+96tCEZx/0rZ/mD4/ShyF5Ve8eNWhfSJQf5uXyXqbMzDov+rrAqvk89cT/r8bal4XhHwAySH15A==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@sheerun/mutationobserver-shim" "^0.3.2"
@@ -1103,9 +1103,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.1.tgz#d5544f6de0aae03eefbb63d5120f6c8be0691946"
-  integrity sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ==
+  version "12.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
+  integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
 
 "@types/prop-types@*":
   version "15.7.1"
@@ -2912,9 +2912,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981:
-  version "1.0.30000981"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000981.tgz#5b6828803362363e5a1deba2eb550185cf6cec8f"
-  integrity sha512-JTByHj4DQgL2crHNMK6PibqAMrqqb/Vvh0JrsTJVSWG4VSUrT16EklkuRZofurlMjgA9e+zlCM4Y39F3kootMQ==
+  version "1.0.30000983"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000983.tgz#ab3c70061ca2a3467182a10ac75109b199b647f8"
+  integrity sha512-/llD1bZ6qwNkt41AsvjsmwNOoA4ZB+8iqmf5LVyeSXuBODT/hAMFNVOh84NdUzoiYiSKqo5vQ3ZzeYHSi/olDQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3370,7 +3370,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -4684,12 +4684,13 @@ fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fetch-mock@^7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.3.tgz#d1abdf309cdef8adb4b0fc0596d3f97fcfbd4528"
-  integrity sha512-MHKcwZ4n9TmnfnVfelUBrrfxtC9tztafIR+F8l/Yu9N+y48fU1BAwj3iSxhYFYELVw73rCZh2DPWtWCekY/t+w==
+fetch-mock@^7.3.6:
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.6.tgz#81c002bfbf11db185e14d20221541bf90560269e"
+  integrity sha512-o/TgQDn9IVdZlpZcQCg/JytEh+fliDQGiF9HSVDj161OJ3dnrLvHomD4F3gDcqXuDePlRYQ2iz0gtEQ/oG3Wfg==
   dependencies:
     babel-polyfill "^6.26.0"
+    core-js "^2.6.9"
     glob-to-regexp "^0.4.0"
     path-to-regexp "^2.2.1"
     whatwg-url "^6.5.0"
@@ -6919,9 +6920,9 @@ locate-path@^3.0.0:
     path-exists "^3.0.0"
 
 lodash-es@^4.2.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
-  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.14.tgz#12a95a963cc5955683cee3b74e85458954f37ecc"
+  integrity sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA==
 
 lodash.assign@^4.0.9:
   version "4.2.0"
@@ -6999,9 +7000,9 @@ lodash.uniq@^4.5.0:
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
 log-driver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
The goal is to create reusable actions for most object types. We could probably add a generic `createObject` action too, and `deleteObject` if we need it.

![drying dog](https://images.baxterboo.com/global/images/article/E99933E5-5056-800A-6B89B889D79D6223.jpg)