### PR TITLE
Focus fixed for retrieve metadata modal

### DIFF
--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@salesforce/design-system-react/components/checkbox';
 import Icon from '@salesforce/design-system-react/components/icon';
 import Tooltip from '@salesforce/design-system-react/components/tooltip';
 import classNames from 'classnames';
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -207,6 +207,12 @@ const ChangesForm = ({
   ) => {
     updateChecked(ignoredChanges, checked);
   };
+  const checkboxRef = useRef(null);
+  useEffect(() => {
+    if (checkboxRef.current && checkboxRef.current?.input) {
+      checkboxRef.current.input.focus();
+    }
+  }, [totalChanges]);
 
   return (
     <form
@@ -239,6 +245,7 @@ const ChangesForm = ({
                 indeterminate={Boolean(!allChangesChecked && !noChangesChecked)}
                 errorText={errors.changes}
                 onChange={handleSelectAllChange}
+                ref={checkboxRef}
               />
               <span className="slds-text-body_regular slds-p-top_xxx-small">
                 ({totalChanges})


### PR DESCRIPTION
[W-11151599](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000xB0kaYAC/view)

Focus order changed from the footer Go back button to the modal content.